### PR TITLE
Fix Github URL

### DIFF
--- a/fly.io-rails.gemspec
+++ b/fly.io-rails.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
     "Sam Ruby",
   ]
   spec.email       = "rubys@intertwingly.net"
-  spec.homepage    = "https://github.com/rubys/fly-io.rails"
+  spec.homepage    = "https://github.com/rubys/fly.io-rails"
   spec.summary     = "Rails support for Fly-io"
   spec.license     = "Apache-2.0"
 


### PR DESCRIPTION
The wires got crossed with the . and the -

Also should we move this over to superfly?