### PR TITLE
Add vips when image_processing gem is present

### DIFF
--- a/lib/fly.io-rails/scanner.rb
+++ b/lib/fly.io-rails/scanner.rb
@@ -18,6 +18,7 @@ module Fly
       @sidekiq = gemfile.include? 'sidekiq'
       @anycable = gemfile.include? 'anycable'
       @rmagick = gemfile.include? 'rmagick'
+      @image_processing = gemfile.include? 'image_processing'
       @bootstrap = gemfile.include? 'bootstrap'
       @puppeteer = gemfile.include? 'puppeteer'
 

--- a/lib/generators/templates/Dockerfile.erb
+++ b/lib/generators/templates/Dockerfile.erb
@@ -154,6 +154,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
   @deploy_packages << 'default-mysql-client' if @mysql
   @deploy_packages << 'google-chrome-stable' if @puppeteer
   @deploy_packages << 'imagemagick' if @rmagick
+  @deploy_packages << 'libvips42' if @image_processing
   @deploy_packages << 'nodejs' if not @node and @bootstrap
   @deploy_packages << 'fuse' if @litefs
   @deploy_packages << 'ruby-foreman' if @procs.length > 1


### PR DESCRIPTION
I had a LoadError in ActiveStorage::Representations::RedirectController#show
```
LoadError
Could not open library 'glib-2.0.so.0': glib-2.0.so.0: cannot open shared object file: No such file or directory.
Could not open library 'libglib-2.0.so.0': libglib-2.0.so.0: cannot open shared object file: No such file or directory
```
Took me a while to figure it out, but adding `libvips42` fixed it, and images are now resizing.

Since vips is default from Rails 7 on, I think this should be in the template.